### PR TITLE
Added read term for lore rando

### DIFF
--- a/TheRealJournalRando/Resources/Logic/waypoints.json
+++ b/TheRealJournalRando/Resources/Logic/waypoints.json
@@ -803,7 +803,7 @@
   },
   {
     "name": "Defeated_Colosseum_3",
-    "logic": "Room_Colosseum_01[left1] + Can_Replenish_Geo + (ANYCLAW | (SPICYCOMBATSKIPS + WINGS)) + COMBAT[Colosseum_3]",
+    "logic": "Room_Colosseum_01[left1] + Can_Replenish_Geo + (ANYCLAW | (SPICYCOMBATSKIPS + WINGS)) + COMBAT[Colosseum_3] + (READ ? ANY)",
     "Stateless": true
   },
   {


### PR DESCRIPTION
Added optional read term to support lore rando.
Before LoreMaster did take care of this, but with the "new logic", I feel like it's easier to just add this here.

The other two locations which LoreMaster did modify earlier are no longer blocked.